### PR TITLE
Fixed issue where interfaces fields were not always in the right order

### DIFF
--- a/gsonpath-compiler/src/main/java/gsonpath/generator/FieldPathInfo.java
+++ b/gsonpath-compiler/src/main/java/gsonpath/generator/FieldPathInfo.java
@@ -1,11 +1,13 @@
 package gsonpath.generator;
 
 public class FieldPathInfo {
+    public final int fieldIndex;
     public final FieldInfo fieldInfo;
     public final String jsonPath;
     public final boolean isRequired;
 
-    public FieldPathInfo(FieldInfo fieldInfo, String jsonPath, boolean isRequired) {
+    public FieldPathInfo(int fieldIndex, FieldInfo fieldInfo, String jsonPath, boolean isRequired) {
+        this.fieldIndex = fieldIndex;
         this.fieldInfo = fieldInfo;
         this.jsonPath = jsonPath;
         this.isRequired = isRequired;

--- a/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/valid/TestValidInterface.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/valid/TestValidInterface.java
@@ -9,4 +9,7 @@ public interface TestValidInterface {
     Integer getValue1();
 
     Integer getValue2();
+
+    @SerializedName("Json1.Nest3")
+    Integer getValue3();
 }

--- a/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/valid/TestValidInterface_GsonPathModel.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/valid/TestValidInterface_GsonPathModel.java
@@ -7,10 +7,12 @@ import java.lang.Override;
 public final class TestValidInterface_GsonPathModel implements TestValidInterface {
     private final Integer value1;
     private final Integer value2;
+    private final Integer value3;
 
-    public TestValidInterface_GsonPathModel(Integer value1, Integer value2) {
+    public TestValidInterface_GsonPathModel(Integer value1, Integer value2, Integer value3) {
         this.value1 = value1;
         this.value2 = value2;
+        this.value3 = value3;
     }
 
     @Override
@@ -24,6 +26,11 @@ public final class TestValidInterface_GsonPathModel implements TestValidInterfac
     }
 
     @Override
+    public Integer getValue3() {
+        return value3;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
@@ -32,6 +39,7 @@ public final class TestValidInterface_GsonPathModel implements TestValidInterfac
 
         if ((value1 == null || !value1.equals(that.value1))) return false;
         if ((value2 == null || !value2.equals(that.value2))) return false;
+        if ((value3 == null || !value3.equals(that.value3))) return false;
 
         return true;
     }
@@ -40,6 +48,7 @@ public final class TestValidInterface_GsonPathModel implements TestValidInterfac
     public int hashCode() {
         int result = value1 != null ? value1.hashCode() : 0;
         result = 31 * result + (value2 != null ? value2.hashCode() : 0);
+        result = 31 * result + (value3 != null ? value3.hashCode() : 0);
         return result;
     }
 }

--- a/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/valid/TestValidInterface_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/valid/TestValidInterface_GsonTypeAdapter.java
@@ -26,6 +26,7 @@ public final class TestValidInterface_GsonTypeAdapter extends TypeAdapter<TestVa
         }
         java.lang.Integer value_Json1_Nest1 = null;
         java.lang.Integer value_value2 = null;
+        java.lang.Integer value_Json1_Nest3 = null;
 
         int jsonFieldCounter0 = 0;
         in.beginObject();
@@ -48,7 +49,7 @@ public final class TestValidInterface_GsonTypeAdapter extends TypeAdapter<TestVa
                     in.beginObject();
 
                     while (in.hasNext()) {
-                        if (jsonFieldCounter1 == 1) {
+                        if (jsonFieldCounter1 == 2) {
                             in.skipValue();
                             continue;
                         }
@@ -58,6 +59,12 @@ public final class TestValidInterface_GsonTypeAdapter extends TypeAdapter<TestVa
                                 jsonFieldCounter1++;
 
                                 value_Json1_Nest1 = getIntegerSafely(in);
+                                break;
+
+                            case "Nest3":
+                                jsonFieldCounter1++;
+
+                                value_Json1_Nest3 = getIntegerSafely(in);
                                 break;
 
                             default:
@@ -85,7 +92,8 @@ public final class TestValidInterface_GsonTypeAdapter extends TypeAdapter<TestVa
         in.endObject();
         return new TestValidInterface_GsonPathModel(
                 value_Json1_Nest1,
-                value_value2
+                value_value2,
+                value_Json1_Nest3
         );
     }
 


### PR DESCRIPTION
This fixes issue #45 by preserving the order of the fields from the interface when calling the concrete implementations constructor within the Type Adapter.