### PR TITLE
Issue #53: Fixed incorrect equals method for annotated terfaces

### DIFF
--- a/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/ModelInterfaceGenerator.java
+++ b/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/ModelInterfaceGenerator.java
@@ -117,10 +117,10 @@ class ModelInterfaceGenerator extends Generator {
                 toStringCodeBlock.addStatement("if ($L != that.$L) return false", fieldName, fieldName);
             } else {
                 if (typeName instanceof ArrayTypeName) {
-                    toStringCodeBlock.addStatement("if (java.util.Arrays.equals($L, that.$L))", fieldName, fieldName);
+                    toStringCodeBlock.addStatement("if (!java.util.Arrays.equals($L, that.$L)) return false", fieldName, fieldName);
 
                 } else {
-                    toStringCodeBlock.addStatement("if (($L == null || !$L.equals(that.$L))) return false", fieldName, fieldName, fieldName);
+                    toStringCodeBlock.addStatement("if ($L != null ? !$L.equals(that.$L) : that.$L != null) return false", fieldName, fieldName, fieldName, fieldName);
                 }
             }
 

--- a/gsonpath-sample/src/test/java/gsonpath/interface_test/InterfaceEqualityTest.java
+++ b/gsonpath-sample/src/test/java/gsonpath/interface_test/InterfaceEqualityTest.java
@@ -1,0 +1,38 @@
+package gsonpath.interface_test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import gsonpath.GsonPath;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStreamReader;
+
+public class InterfaceEqualityTest {
+    @Test
+    public void onAssertEquals_givenSameJson_expectEqual() {
+        compareJsonFiles("InterfaceEqualityVariant1TestJson.json", "InterfaceEqualityVariant1TestJson.json", true);
+    }
+
+    @Test
+    public void onAssertEquals_givenDifferentJson_expectNotEqual() {
+        compareJsonFiles("InterfaceEqualityVariant1TestJson.json", "InterfaceEqualityVariant2TestJson.json", false);
+    }
+
+    private void compareJsonFiles(String filename1, String filename2, boolean expectEqual) {
+        GsonBuilder builder = new GsonBuilder();
+        builder.registerTypeAdapterFactory(GsonPath.createTypeAdapterFactory());
+        Gson gson = builder.create();
+
+        ClassLoader classLoader = ClassLoader.getSystemClassLoader();
+        InterfaceExample sample1 = gson.fromJson(new InputStreamReader(classLoader.getResourceAsStream(filename1)), InterfaceExample.class);
+        InterfaceExample sample2 = gson.fromJson(new InputStreamReader(classLoader.getResourceAsStream(filename2)), InterfaceExample.class);
+
+        if (expectEqual) {
+            Assert.assertEquals(sample1, sample2);
+        } else {
+            Assert.assertNotEquals(sample1, sample2);
+        }
+    }
+
+}

--- a/gsonpath-sample/src/test/java/gsonpath/interface_test/InterfaceExample.java
+++ b/gsonpath-sample/src/test/java/gsonpath/interface_test/InterfaceExample.java
@@ -1,0 +1,22 @@
+package gsonpath.interface_test;
+
+import gsonpath.AutoGsonAdapter;
+
+@AutoGsonAdapter
+public interface InterfaceExample {
+    Integer getIntExample();
+
+    Long getLongExample();
+
+    Double getDoubleExample();
+
+    Boolean getBooleanExample();
+
+    Integer[] getIntArrayExample();
+
+    Long[] getLongArrayExample();
+
+    Double[] getDoubleArrayExample();
+
+    Boolean[] getBooleanArrayExample();
+}

--- a/gsonpath-sample/src/test/resources/InterfaceEqualityVariant1TestJson.json
+++ b/gsonpath-sample/src/test/resources/InterfaceEqualityVariant1TestJson.json
@@ -1,0 +1,25 @@
+{
+    "intExample": 1,
+    "longExample": 1000,
+    "doubleExample": 2.5,
+    "booleanExample": true,
+    "intArrayExample": [
+        1,
+        2,
+        3
+    ],
+    "longArrayExample": [
+        1000,
+        2000,
+        3000
+    ],
+    "doubleArrayExample": [
+        2.5,
+        3.5,
+        4.5
+    ],
+    "booleanArrayExample": [
+        true,
+        false
+    ]
+}

--- a/gsonpath-sample/src/test/resources/InterfaceEqualityVariant2TestJson.json
+++ b/gsonpath-sample/src/test/resources/InterfaceEqualityVariant2TestJson.json
@@ -1,0 +1,25 @@
+{
+    "intExample": -1,
+    "longExample": -1000,
+    "doubleExample": -2.5,
+    "booleanExample": false,
+    "intArrayExample": [
+        -1,
+        -2,
+        -3
+    ],
+    "longArrayExample": [
+        -1000,
+        -2000,
+        -3000
+    ],
+    "doubleArrayExample": [
+        -2.5,
+        -3.5,
+        -4.5
+    ],
+    "booleanArrayExample": [
+        false,
+        true
+    ]
+}


### PR DESCRIPTION
This fixes the issue where the generated equals methods did not correctly test equality.

The new equals method is Java 6 compliant and is written in the same style that IntelliJ Idea generates it