### PR TITLE
Issue #59 Model interface generator now copies interface annotations

### DIFF
--- a/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/ModelInterfaceGenerator.java
+++ b/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/ModelInterfaceGenerator.java
@@ -8,10 +8,7 @@ import gsonpath.model.InterfaceFieldInfo;
 import gsonpath.model.InterfaceInfo;
 
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.Modifier;
-import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.*;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
 import java.util.ArrayList;
@@ -107,6 +104,12 @@ class ModelInterfaceGenerator extends Generator {
                     .returns(typeName);
 
             accessorMethod.addCode("return $L;\n", fieldName);
+
+            // Copy all annotations from the interface accessor method to the implementing classes accessor.
+            List<? extends AnnotationMirror> annotationMirrors = enclosedElement.getAnnotationMirrors();
+            for (AnnotationMirror annotationMirror : annotationMirrors) {
+                accessorMethod.addAnnotation(AnnotationSpec.get(annotationMirror));
+            }
 
             typeBuilder.addMethod(accessorMethod.build());
 

--- a/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/flatten_json/TestFlattenJsonWithInterface_GsonPathModel.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/flatten_json/TestFlattenJsonWithInterface_GsonPathModel.java
@@ -1,5 +1,7 @@
 package adapter.auto.interface_example.flatten_json;
 
+import gsonpath.FlattenJson;
+
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -12,6 +14,7 @@ public final class TestFlattenJsonWithInterface_GsonPathModel implements TestFla
     }
 
     @Override
+    @FlattenJson
     public String getFlattenExample() {
         return flattenExample;
     }

--- a/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/inheritance/TestUsingInheritance_GsonPathModel.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/inheritance/TestUsingInheritance_GsonPathModel.java
@@ -1,5 +1,7 @@
 package adapter.auto.interface_example.inheritance;
 
+import com.google.gson.annotations.SerializedName;
+import gsonpath.NonNull;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -22,11 +24,13 @@ public final class TestUsingInheritance_GsonPathModel implements TestUsingInheri
     }
 
     @Override
+    @NonNull
     public Integer getValue1() {
         return value1;
     }
 
     @Override
+    @SerializedName("Json1.Nest2")
     public Integer getValue2() {
         return value2;
     }

--- a/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/valid/TestValidInterface_GsonPathModel.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/interface_example/valid/TestValidInterface_GsonPathModel.java
@@ -1,5 +1,7 @@
 package adapter.auto.interface_example.valid;
 
+import com.google.gson.annotations.SerializedName;
+
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -17,6 +19,7 @@ public final class TestValidInterface_GsonPathModel implements TestValidInterfac
     }
 
     @Override
+    @SerializedName("Json1.Nest1")
     public Integer getValue1() {
         return value1;
     }
@@ -27,6 +30,7 @@ public final class TestValidInterface_GsonPathModel implements TestValidInterfac
     }
 
     @Override
+    @SerializedName("Json1.Nest3")
     public Integer getValue3() {
         return value3;
     }


### PR DESCRIPTION
Fixed issue #59 which required updating the model interface generator to correctly copy the annotations from the interface accessor methods to the implementing classes accessor methods.

Without making this change, IntelliJ would complain that the implementing POJO was not using the correct annotations.