### PR TITLE
Issue 58: Allowed models to be package private

### DIFF
--- a/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/TypeAdapterLoaderGenerator.java
+++ b/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/TypeAdapterLoaderGenerator.java
@@ -3,11 +3,9 @@ package gsonpath.generator.adapter;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
-import com.squareup.javapoet.CodeBlock;
-import com.squareup.javapoet.MethodSpec;
-import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.*;
 
-import java.util.List;
+import java.util.*;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Modifier;
@@ -17,6 +15,7 @@ import gsonpath.generator.HandleResult;
 import gsonpath.internal.TypeAdapterLoader;
 
 public class TypeAdapterLoaderGenerator extends Generator {
+    private static final String PACKAGE_PRIVATE_TYPE_ADAPTER_LOADER_CLASS_NAME = "PackagePrivateTypeAdapterLoader";
 
     public TypeAdapterLoaderGenerator(ProcessingEnvironment processingEnv) {
         super(processingEnv);
@@ -27,8 +26,92 @@ public class TypeAdapterLoaderGenerator extends Generator {
             return false;
         }
 
-        // Create the GsonPathLoader which is used by the GsonPathTypeAdapterFactory class.
+        Map<String, List<HandleResult>> packageLocalHandleResults = new HashMap<>();
+        for (HandleResult generatedGsonAdapter : generatedGsonAdapters) {
+            String packageName = generatedGsonAdapter.generatedClassName.packageName();
+
+            List<HandleResult> localResults = packageLocalHandleResults.get(packageName);
+            if (localResults == null) {
+                localResults = new ArrayList<>();
+                packageLocalHandleResults.put(packageName, localResults);
+            }
+
+            localResults.add(generatedGsonAdapter);
+        }
+
+        for (String packageName : packageLocalHandleResults.keySet()) {
+            if (!createPackageLocalTypeAdapterLoaders(packageName, packageLocalHandleResults.get(packageName))) {
+                // If any of the package local adapters fail to generate, we must fail the entire process.
+                return false;
+            }
+        }
+
+        return createRootTypeAdapterLoader(packageLocalHandleResults);
+    }
+
+    /**
+     * Create the GsonPathLoader which is used by the GsonPathTypeAdapterFactory class.
+     */
+    private boolean createRootTypeAdapterLoader(Map<String, List<HandleResult>> packageLocalHandleResults) {
         TypeSpec.Builder typeBuilder = TypeSpec.classBuilder("GeneratedTypeAdapterLoader")
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+                .addSuperinterface(TypeAdapterLoader.class);
+
+        typeBuilder.addField(FieldSpec.builder(ParameterizedTypeName.get(HashMap.class, String.class, TypeAdapterLoader.class), "mPackagePrivateLoaders")
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build());
+
+        MethodSpec.Builder constructorBuilder = MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC);
+
+        CodeBlock.Builder constructorCodeBlock = CodeBlock.builder();
+        constructorCodeBlock.addStatement("mPackagePrivateLoaders = new HashMap<>()");
+        constructorCodeBlock.add("\n");
+
+        // Add the package local type adapter loaders to the hash map.
+        for (String packageName : packageLocalHandleResults.keySet()) {
+            String loaderName = packageName.replace(".", "_") + "_Loader";
+            constructorCodeBlock.addStatement("$T $L = new $L.$L()", TypeAdapterLoader.class, loaderName, packageName, PACKAGE_PRIVATE_TYPE_ADAPTER_LOADER_CLASS_NAME);
+
+            for (HandleResult handleResult : packageLocalHandleResults.get(packageName)) {
+                constructorCodeBlock.addStatement("mPackagePrivateLoaders.put(\"$L\", $L)", handleResult.originalClassName.toString(), loaderName);
+            }
+            constructorCodeBlock.add("\n");
+        }
+
+        constructorBuilder.addCode(constructorCodeBlock.build());
+        typeBuilder.addMethod(constructorBuilder.build());
+
+        //
+        // <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type);
+        //
+        MethodSpec.Builder createMethod = MethodSpec.methodBuilder("create")
+                .addAnnotation(Override.class)
+                .addModifiers(Modifier.PUBLIC)
+                .returns(TypeAdapter.class)
+                .addParameter(Gson.class, "gson")
+                .addParameter(TypeToken.class, "type");
+
+        CodeBlock.Builder codeBlock = CodeBlock.builder();
+        codeBlock.addStatement("Class rawType = type.getRawType()");
+        codeBlock.add("\n");
+
+        codeBlock.addStatement("TypeAdapterLoader typeAdapterLoader = mPackagePrivateLoaders.get(rawType.getName())");
+        codeBlock.beginControlFlow("if (typeAdapterLoader != null)");
+        codeBlock.addStatement("return typeAdapterLoader.create(gson, type)");
+        codeBlock.endControlFlow();
+
+        codeBlock.add("\n");
+        codeBlock.addStatement("return null");
+
+        createMethod.addCode(codeBlock.build());
+        typeBuilder.addMethod(createMethod.build());
+
+        return writeFile("gsonpath", typeBuilder);
+    }
+
+    private boolean createPackageLocalTypeAdapterLoaders(String packageName, List<HandleResult> packageLocalGsonAdapters) {
+        TypeSpec.Builder typeBuilder = TypeSpec.classBuilder(ClassName.get(packageName, PACKAGE_PRIVATE_TYPE_ADAPTER_LOADER_CLASS_NAME))
                 .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
                 .addSuperinterface(TypeAdapterLoader.class);
 
@@ -46,14 +129,14 @@ public class TypeAdapterLoaderGenerator extends Generator {
         codeBlock.addStatement("Class rawType = type.getRawType()");
 
         int currentAdapterIndex = 0;
-        for (HandleResult result : generatedGsonAdapters) {
+        for (HandleResult result : packageLocalGsonAdapters) {
             if (currentAdapterIndex == 0) {
-                codeBlock.beginControlFlow("if (rawType.equals($L.class))", result.originalClassName.toString());
+                codeBlock.beginControlFlow("if (rawType.equals($T.class))", result.originalClassName);
             } else {
                 codeBlock.add("\n"); // New line for easier readability.
-                codeBlock.nextControlFlow("else if (rawType.equals($L.class))", result.originalClassName.toString());
+                codeBlock.nextControlFlow("else if (rawType.equals($T.class))", result.originalClassName);
             }
-            codeBlock.addStatement("return new $L(gson)", result.generatedClassName.toString());
+            codeBlock.addStatement("return new $T(gson)", result.generatedClassName);
 
             currentAdapterIndex++;
         }
@@ -64,7 +147,7 @@ public class TypeAdapterLoaderGenerator extends Generator {
         createMethod.addCode(codeBlock.build());
         typeBuilder.addMethod(createMethod.build());
 
-        return writeFile("gsonpath", typeBuilder);
+        return writeFile(packageName, typeBuilder);
     }
 
 }

--- a/gsonpath-compiler/src/test/java/gsonpath/generator/adapter/loader/TypeAdapterLoaderGeneratorTest.java
+++ b/gsonpath-compiler/src/test/java/gsonpath/generator/adapter/loader/TypeAdapterLoaderGeneratorTest.java
@@ -7,8 +7,13 @@ public class TypeAdapterLoaderGeneratorTest extends BaseGeneratorTest {
     @Test
     public void testGeneratedLoader() {
         assertGeneratedContent(new BaseGeneratorTest.TestCriteria("adapter/loader")
-                .addRelativeSource("TestLoaderSource1.java")
-                .addRelativeSource("TestLoaderSource2.java")
-                .addRelativeGenerated("GeneratedTypeAdapterLoader.java"));
+                .addRelativeSource("TestLoaderSource.java")
+                .addRelativeSource("source2/TestLoaderSource.java")
+                .addRelativeSource("source2/TestLoaderSource2.java")
+                .addRelativeSource("source3/TestLoaderSource.java")
+                .addRelativeGenerated("GeneratedTypeAdapterLoader.java")
+                .addRelativeGenerated("PackagePrivateTypeAdapterLoader.java")
+                .addRelativeGenerated("source2/PackagePrivateTypeAdapterLoader.java")
+                .addRelativeGenerated("source3/PackagePrivateTypeAdapterLoader.java"));
     }
 }

--- a/gsonpath-compiler/src/test/resources/adapter/loader/GeneratedTypeAdapterLoader.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/GeneratedTypeAdapterLoader.java
@@ -4,18 +4,34 @@ import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
 import gsonpath.internal.TypeAdapterLoader;
-
 import java.lang.Override;
+import java.lang.String;
+import java.util.HashMap;
 
 public final class GeneratedTypeAdapterLoader implements TypeAdapterLoader {
+    private final HashMap<String, TypeAdapterLoader> mPackagePrivateLoaders;
+
+    public GeneratedTypeAdapterLoader() {
+        mPackagePrivateLoaders = new HashMap<>();
+
+        TypeAdapterLoader adapter_loader_Loader = new adapter.loader.PackagePrivateTypeAdapterLoader();
+        mPackagePrivateLoaders.put("adapter.loader.TestLoaderSource", adapter_loader_Loader);
+
+        TypeAdapterLoader adapter_loader_source3_Loader = new adapter.loader.source3.PackagePrivateTypeAdapterLoader();
+        mPackagePrivateLoaders.put("adapter.loader.source3.TestLoaderSource", adapter_loader_source3_Loader);
+
+        TypeAdapterLoader adapter_loader_source2_Loader = new adapter.loader.source2.PackagePrivateTypeAdapterLoader();
+        mPackagePrivateLoaders.put("adapter.loader.source2.TestLoaderSource", adapter_loader_source2_Loader);
+        mPackagePrivateLoaders.put("adapter.loader.source2.TestLoaderSource2", adapter_loader_source2_Loader);
+    }
+
     @Override
     public TypeAdapter create(Gson gson, TypeToken type) {
         Class rawType = type.getRawType();
-        if (rawType.equals(adapter.loader.TestLoaderSource1.class)) {
-            return new adapter.loader.TestLoaderSource1_GsonTypeAdapter(gson);
 
-        } else if (rawType.equals(adapter.loader.TestLoaderSource2.class)) {
-            return new adapter.loader.TestLoaderSource2_GsonTypeAdapter(gson);
+        TypeAdapterLoader typeAdapterLoader = mPackagePrivateLoaders.get(rawType.getName());
+        if (typeAdapterLoader != null) {
+            return typeAdapterLoader.create(gson, type);
         }
 
         return null;

--- a/gsonpath-compiler/src/test/resources/adapter/loader/PackagePrivateTypeAdapterLoader.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/PackagePrivateTypeAdapterLoader.java
@@ -1,0 +1,20 @@
+package adapter.loader;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import gsonpath.internal.TypeAdapterLoader;
+import java.lang.Override;
+
+public final class PackagePrivateTypeAdapterLoader implements TypeAdapterLoader {
+    @Override
+    public TypeAdapter create(Gson gson, TypeToken type) {
+        Class rawType = type.getRawType();
+        if (rawType.equals(TestLoaderSource.class)) {
+            return new TestLoaderSource_GsonTypeAdapter(gson);
+
+        }
+
+        return null;
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/loader/TestLoaderSource.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/TestLoaderSource.java
@@ -3,5 +3,5 @@ package adapter.loader;
 import gsonpath.AutoGsonAdapter;
 
 @AutoGsonAdapter
-public class TestLoaderSource1 {
+class TestLoaderSource {
 }

--- a/gsonpath-compiler/src/test/resources/adapter/loader/TestLoaderSource2.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/TestLoaderSource2.java
@@ -1,7 +1,0 @@
-package adapter.loader;
-
-import gsonpath.AutoGsonAdapter;
-
-@AutoGsonAdapter
-public class TestLoaderSource2 {
-}

--- a/gsonpath-compiler/src/test/resources/adapter/loader/source2/PackagePrivateTypeAdapterLoader.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/source2/PackagePrivateTypeAdapterLoader.java
@@ -1,0 +1,22 @@
+package adapter.loader.source2;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import gsonpath.internal.TypeAdapterLoader;
+import java.lang.Override;
+
+public final class PackagePrivateTypeAdapterLoader implements TypeAdapterLoader {
+    @Override
+    public TypeAdapter create(Gson gson, TypeToken type) {
+        Class rawType = type.getRawType();
+        if (rawType.equals(TestLoaderSource.class)) {
+            return new TestLoaderSource_GsonTypeAdapter(gson);
+
+        } else if (rawType.equals(TestLoaderSource2.class)) {
+            return new TestLoaderSource2_GsonTypeAdapter(gson);
+        }
+
+        return null;
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/loader/source2/TestLoaderSource.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/source2/TestLoaderSource.java
@@ -1,0 +1,7 @@
+package adapter.loader.source2;
+
+import gsonpath.AutoGsonAdapter;
+
+@AutoGsonAdapter
+class TestLoaderSource {
+}

--- a/gsonpath-compiler/src/test/resources/adapter/loader/source2/TestLoaderSource2.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/source2/TestLoaderSource2.java
@@ -1,0 +1,7 @@
+package adapter.loader.source2;
+
+import gsonpath.AutoGsonAdapter;
+
+@AutoGsonAdapter
+class TestLoaderSource2 {
+}

--- a/gsonpath-compiler/src/test/resources/adapter/loader/source3/PackagePrivateTypeAdapterLoader.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/source3/PackagePrivateTypeAdapterLoader.java
@@ -1,0 +1,19 @@
+package adapter.loader.source3;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import gsonpath.internal.TypeAdapterLoader;
+import java.lang.Override;
+
+public final class PackagePrivateTypeAdapterLoader implements TypeAdapterLoader {
+    @Override
+    public TypeAdapter create(Gson gson, TypeToken type) {
+        Class rawType = type.getRawType();
+        if (rawType.equals(TestLoaderSource.class)) {
+            return new TestLoaderSource_GsonTypeAdapter(gson);
+        }
+
+        return null;
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/loader/source3/TestLoaderSource.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/source3/TestLoaderSource.java
@@ -1,0 +1,7 @@
+package adapter.loader.source3;
+
+import gsonpath.AutoGsonAdapter;
+
+@AutoGsonAdapter
+class TestLoaderSource {
+}

--- a/gsonpath-sample/src/test/java/gsonpath/generated/StoreModel.java
+++ b/gsonpath-sample/src/test/java/gsonpath/generated/StoreModel.java
@@ -6,18 +6,18 @@ import gsonpath.AutoGsonAdapter;
 import java.util.List;
 
 @AutoGsonAdapter(rootField = "store")
-public class StoreModel {
+class StoreModel {
     @SerializedName("book")
-    public List<BookModel> bookList;
+    List<BookModel> bookList;
 
     @SerializedName("bicycle.color")
-    public String bikeColour;
+    String bikeColour;
 
     @SerializedName("bicycle.price")
-    public double bikePrice;
+    double bikePrice;
 
     @AutoGsonAdapter
-    public static class BookModel {
+    static class BookModel {
         public String category;
         public String author;
         public String title;

--- a/gsonpath-sample/src/test/java/gsonpath/generated/StoreModelTest.java
+++ b/gsonpath-sample/src/test/java/gsonpath/generated/StoreModelTest.java
@@ -1,8 +1,8 @@
-package gsonpath;
+package gsonpath.generated;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import gsonpath.generated.StoreModel;
+import gsonpath.GsonPath;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/gsonpath-sample/src/test/java/gsonpath/interface_test/InterfaceExample.java
+++ b/gsonpath-sample/src/test/java/gsonpath/interface_test/InterfaceExample.java
@@ -3,7 +3,7 @@ package gsonpath.interface_test;
 import gsonpath.AutoGsonAdapter;
 
 @AutoGsonAdapter
-public interface InterfaceExample {
+interface InterfaceExample {
     Integer getIntExample();
 
     Long getLongExample();

--- a/gsonpath-sample/src/test/java/gsonpath/mandatory/MandatorySampleModel.java
+++ b/gsonpath-sample/src/test/java/gsonpath/mandatory/MandatorySampleModel.java
@@ -4,6 +4,6 @@ import gsonpath.AutoGsonAdapter;
 import gsonpath.GsonFieldValidationType;
 
 @AutoGsonAdapter(fieldValidationType = GsonFieldValidationType.VALIDATE_ALL_EXCEPT_NULLABLE)
-public class MandatorySampleModel {
+class MandatorySampleModel {
     int test;
 }

--- a/gsonpath-sample/src/test/java/gsonpath/polymorphism/Type1.java
+++ b/gsonpath-sample/src/test/java/gsonpath/polymorphism/Type1.java
@@ -3,6 +3,6 @@ package gsonpath.polymorphism;
 import gsonpath.AutoGsonAdapter;
 
 @AutoGsonAdapter
-public class Type1 extends Type {
+class Type1 extends Type {
     int intTest;
 }

--- a/gsonpath-sample/src/test/java/gsonpath/polymorphism/Type2.java
+++ b/gsonpath-sample/src/test/java/gsonpath/polymorphism/Type2.java
@@ -3,6 +3,6 @@ package gsonpath.polymorphism;
 import gsonpath.AutoGsonAdapter;
 
 @AutoGsonAdapter
-public class Type2 extends Type {
+class Type2 extends Type {
     double doubleTest;
 }

--- a/gsonpath-sample/src/test/java/gsonpath/polymorphism/Type3.java
+++ b/gsonpath-sample/src/test/java/gsonpath/polymorphism/Type3.java
@@ -3,6 +3,6 @@ package gsonpath.polymorphism;
 import gsonpath.AutoGsonAdapter;
 
 @AutoGsonAdapter
-public class Type3 extends Type {
+class Type3 extends Type {
     String stringTest;
 }


### PR DESCRIPTION
Added feature requested in #58 

POJOs annotated with `@AutoGsonAdapter` can now be package local. A TypeAdapterLoader will now be generated for each required package, allowing greater API flexibility.