### PR TITLE
Issue #58 Fixed package local defect due to nested classes

### DIFF
--- a/gsonpath-compiler/src/test/resources/adapter/loader/GeneratedTypeAdapterLoader.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/GeneratedTypeAdapterLoader.java
@@ -4,36 +4,28 @@ import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
 import gsonpath.internal.TypeAdapterLoader;
+
 import java.lang.Override;
-import java.lang.String;
-import java.util.HashMap;
 
 public final class GeneratedTypeAdapterLoader implements TypeAdapterLoader {
-    private final HashMap<String, TypeAdapterLoader> mPackagePrivateLoaders;
+    private final TypeAdapterLoader[] mPackagePrivateLoaders;
 
     public GeneratedTypeAdapterLoader() {
-        mPackagePrivateLoaders = new HashMap<>();
-
-        TypeAdapterLoader adapter_loader_Loader = new adapter.loader.PackagePrivateTypeAdapterLoader();
-        mPackagePrivateLoaders.put("adapter.loader.TestLoaderSource", adapter_loader_Loader);
-
-        TypeAdapterLoader adapter_loader_source3_Loader = new adapter.loader.source3.PackagePrivateTypeAdapterLoader();
-        mPackagePrivateLoaders.put("adapter.loader.source3.TestLoaderSource", adapter_loader_source3_Loader);
-
-        TypeAdapterLoader adapter_loader_source2_Loader = new adapter.loader.source2.PackagePrivateTypeAdapterLoader();
-        mPackagePrivateLoaders.put("adapter.loader.source2.TestLoaderSource", adapter_loader_source2_Loader);
-        mPackagePrivateLoaders.put("adapter.loader.source2.TestLoaderSource2", adapter_loader_source2_Loader);
+        mPackagePrivateLoaders = new TypeAdapterLoader[3];
+        mPackagePrivateLoaders[0] = new adapter.loader.PackagePrivateTypeAdapterLoader();
+        mPackagePrivateLoaders[1] = new adapter.loader.source3.PackagePrivateTypeAdapterLoader();
+        mPackagePrivateLoaders[2] = new adapter.loader.source2.PackagePrivateTypeAdapterLoader();
     }
 
     @Override
     public TypeAdapter create(Gson gson, TypeToken type) {
-        Class rawType = type.getRawType();
+        for (int i = 0; i < mPackagePrivateLoaders.length; i++) {
+            TypeAdapter typeAdapter = mPackagePrivateLoaders[i].create(gson, type);
 
-        TypeAdapterLoader typeAdapterLoader = mPackagePrivateLoaders.get(rawType.getName());
-        if (typeAdapterLoader != null) {
-            return typeAdapterLoader.create(gson, type);
+            if (typeAdapter != null) {
+                return typeAdapter;
+            }
         }
-
         return null;
     }
 }

--- a/gsonpath-compiler/src/test/resources/adapter/loader/source3/PackagePrivateTypeAdapterLoader.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/source3/PackagePrivateTypeAdapterLoader.java
@@ -12,6 +12,9 @@ public final class PackagePrivateTypeAdapterLoader implements TypeAdapterLoader 
         Class rawType = type.getRawType();
         if (rawType.equals(TestLoaderSource.class)) {
             return new TestLoaderSource_GsonTypeAdapter(gson);
+
+        } else if (rawType.equals(TestLoaderSource.Inner.class)) {
+            return new TestLoaderSource_Inner_GsonTypeAdapter(gson);
         }
 
         return null;

--- a/gsonpath-compiler/src/test/resources/adapter/loader/source3/TestLoaderSource.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/source3/TestLoaderSource.java
@@ -4,4 +4,8 @@ import gsonpath.AutoGsonAdapter;
 
 @AutoGsonAdapter
 class TestLoaderSource {
+    @AutoGsonAdapter
+    static class Inner {
+
+    }
 }


### PR DESCRIPTION
Fixed an issue introduced by PR #61 

There were previously no unit tests to see how the library dealt with nested classes. The mechanism used to reference the classes by their names did not correctly work with nested classes.

The mechanism has been updated to be more type safe, and a unit test has been added for nested classes.