### PR TITLE
Bugfix/auto factory public constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Change Log
 ==========
 
+Version 2.0.0-beta2 *(2017-02-14)*
+----------------------------
+
+* Fix: The TypeAdapterFactory generated via the `@AutoGsonAdapterFactory` now has a public constructor
+     * This was causing issues in projects that use proguard.
+
 Version 2.0.0-beta1 *(2017-02-13)*
 ----------------------------
 

--- a/gsonpath-compiler/build.gradle
+++ b/gsonpath-compiler/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'net.lachlanmckee'
-version = '2.0.0-beta1'
+version = '2.0.0-beta2'
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/factory/TypeAdapterFactoryGenerator.kt
+++ b/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/factory/TypeAdapterFactoryGenerator.kt
@@ -61,6 +61,7 @@ class TypeAdapterFactoryGenerator(processingEnv: ProcessingEnvironment) : Genera
                 .build())
 
         val constructorBuilder = MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
 
         val constructorCodeBlock = CodeBlock.builder()
         constructorCodeBlock.addStatement("mPackagePrivateLoaders = new \$T[${packageLocalHandleResults.size}]", TypeAdapterFactory::class.java)

--- a/gsonpath-compiler/src/test/resources/adapter/loader/TestGsonTypeFactoryImpl.java
+++ b/gsonpath-compiler/src/test/resources/adapter/loader/TestGsonTypeFactoryImpl.java
@@ -10,7 +10,7 @@ import java.lang.Override;
 public final class TestGsonTypeFactoryImpl implements TestGsonTypeFactory {
     private final TypeAdapterFactory[] mPackagePrivateLoaders;
 
-    GsonTypeAdapterLoader() {
+    public GsonTypeAdapterLoader() {
         mPackagePrivateLoaders = new TypeAdapterFactory[3];
         mPackagePrivateLoaders[0] = new adapter.loader.PackagePrivateTypeAdapterLoader();
         mPackagePrivateLoaders[1] = new adapter.loader.source3.PackagePrivateTypeAdapterLoader();

--- a/gsonpath/build.gradle
+++ b/gsonpath/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 
 group = 'net.lachlanmckee'
-version = '2.0.0-beta1'
+version = '2.0.0-beta2'
 
 targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7

--- a/gsonpath/src/main/java/gsonpath/GsonPath.java
+++ b/gsonpath/src/main/java/gsonpath/GsonPath.java
@@ -28,7 +28,7 @@ public class GsonPath {
         try {
             return (TypeAdapterFactory) Class.forName(factoryClassName).newInstance();
         } catch (Exception e) {
-            throw new RuntimeException("Unable to find generated TypeAdapterFactory '" + factoryClassName + "'");
+            throw new RuntimeException("Unable to instantiate generated TypeAdapterFactory '" + factoryClassName + "'", e);
         }
     }
 }


### PR DESCRIPTION
Fixed an issue where the automatically generated TypeAdapterFactory added in 2.0.0-beta1 was not able to be instantiated due to a non-public constructor.