### PR TITLE
Issue #69 - Added missing generics support

### DIFF
--- a/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/interf/ModelInterfaceGenerator.kt
+++ b/gsonpath-compiler/src/main/java/gsonpath/generator/adapter/interf/ModelInterfaceGenerator.kt
@@ -20,6 +20,7 @@ import gsonpath.internal.GsonPathElementList
 import com.squareup.javapoet.TypeSpec
 import gsonpath.generator.adapter.generateClassName
 import gsonpath.generator.adapter.addNewLine
+import javax.lang.model.type.DeclaredType
 
 internal class ModelInterfaceGenerator(processingEnv: ProcessingEnvironment) : Generator(processingEnv) {
 
@@ -133,8 +134,10 @@ internal class ModelInterfaceGenerator(processingEnv: ProcessingEnvironment) : G
             val enclosedElement = methodElements[elementIndex]
 
             val methodType = enclosedElement.asType() as ExecutableType
-            val returnType = methodType.returnType
-            val typeName = TypeName.get(returnType)
+
+            // Ensure that any generics have been converted into their actual return types.
+            val typeName = TypeName.get((processingEnv.typeUtils.asMemberOf(element.asType() as DeclaredType, enclosedElement)
+                    as ExecutableType).returnType)
 
             if (typeName == null || typeName == TypeName.VOID) {
                 throw ProcessingException("Gson Path interface methods must have a return type", enclosedElement)

--- a/gsonpath-compiler/src/main/java/gsonpath/model/FieldInfoFactory.kt
+++ b/gsonpath-compiler/src/main/java/gsonpath/model/FieldInfoFactory.kt
@@ -7,6 +7,7 @@ import gsonpath.ExcludeField
 import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.*
 import java.util.ArrayList
+import javax.lang.model.type.DeclaredType
 
 class FieldInfoFactory(private val processingEnv: ProcessingEnvironment) {
 
@@ -36,9 +37,12 @@ class FieldInfoFactory(private val processingEnv: ProcessingEnvironment) {
                 continue
             }
 
+            // Ensure that any generics have been converted into their actual class.
+            val generifiedElement = processingEnv.typeUtils.asMemberOf(modelElement.asType() as DeclaredType, memberElement)
+
             fieldInfoList.add(object : FieldInfo {
                 override val typeName: TypeName
-                    get() = TypeName.get(memberElement.asType())
+                    get() = TypeName.get(generifiedElement)
 
                 override val parentClassName: String
                     get() = memberElement.enclosingElement.toString()

--- a/gsonpath-compiler/src/test/java/gsonpath/generator/adapter/auto/GenericsTest.kt
+++ b/gsonpath-compiler/src/test/java/gsonpath/generator/adapter/auto/GenericsTest.kt
@@ -1,0 +1,33 @@
+package gsonpath.generator.adapter.auto
+
+import gsonpath.generator.BaseGeneratorTest
+import org.junit.Test
+
+class GenericsTest : BaseGeneratorTest() {
+    @Test
+    fun testUseInheritance() {
+        assertGeneratedContent(BaseGeneratorTest.TestCriteria("adapter/auto/generics/interfaces")
+                .addRelativeSource("BaseTest.java")
+                .addRelativeSource("GenericsTest.java")
+                .addRelativeGenerated("GenericsTest_GsonPathModel.java")
+                .addRelativeGenerated("GenericsTest_GsonTypeAdapter.java"))
+    }
+
+    @Test
+    fun testUseClass() {
+        assertGeneratedContent(BaseGeneratorTest.TestCriteria("adapter/auto/generics/classes")
+                .addRelativeSource("BaseTest.java")
+                .addRelativeSource("IntermediateTest.java")
+                .addRelativeSource("GenericsTest.java")
+                .addRelativeGenerated("GenericsTest_GsonTypeAdapter.java"))
+    }
+
+    @Test
+    fun testUseInterfaceAndClass() {
+        assertGeneratedContent(BaseGeneratorTest.TestCriteria("adapter/auto/generics/interfaces_and_classs")
+                .addRelativeSource("BaseTest.java")
+                .addRelativeSource("IntermediateTest.java")
+                .addRelativeSource("GenericsTest.java")
+                .addRelativeGenerated("GenericsTest_GsonTypeAdapter.java"))
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/classes/BaseTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/classes/BaseTest.java
@@ -1,0 +1,10 @@
+package adapter.auto.generics.classes;
+
+import java.util.List;
+import java.util.Map;
+
+class BaseTest<GENERIC_1, GENERIC_2, GENERIC_3> {
+    GENERIC_1 value1;
+
+    Map<GENERIC_2, GENERIC_3> value2;
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/classes/GenericsTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/classes/GenericsTest.java
@@ -1,0 +1,7 @@
+package adapter.auto.generics.classes;
+
+import gsonpath.AutoGsonAdapter;
+
+@AutoGsonAdapter
+class GenericsTest extends IntermediateTest<String, Double> {
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/classes/GenericsTest_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/classes/GenericsTest_GsonTypeAdapter.java
@@ -1,0 +1,108 @@
+package adapter.auto.generics.classes;
+
+import static gsonpath.GsonUtil.*;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Map;
+
+public final class GenericsTest_GsonTypeAdapter extends TypeAdapter<GenericsTest> {
+    private final Gson mGson;
+
+    public GenericsTest_GsonTypeAdapter(Gson gson) {
+        this.mGson = gson;
+    }
+
+    @Override
+    public GenericsTest read(JsonReader in) throws IOException {
+        // Ensure the object is not null.
+        if (!isValidValue(in)) {
+            return null;
+        }
+        GenericsTest result = new GenericsTest();
+
+        int jsonFieldCounter0 = 0;
+        in.beginObject();
+
+        while (in.hasNext()) {
+            if (jsonFieldCounter0 == 3) {
+                in.skipValue();
+                continue;
+            }
+
+            switch (in.nextName()) {
+                case "value1":
+                    jsonFieldCounter0++;
+
+                    String value_value1 = getStringSafely(in);
+                    if (value_value1 != null) {
+                        result.value1 = value_value1;
+                    }
+                    break;
+
+                case "value2":
+                    jsonFieldCounter0++;
+
+                    java.util.Map<java.lang.String, java.lang.Integer> value_value2 = mGson.getAdapter(new com.google.gson.reflect.TypeToken<java.util.Map<java.lang.String, java.lang.Integer>>(){}).read(in);
+                    if (value_value2 != null) {
+                        result.value2 = value_value2;
+                    }
+                    break;
+
+                case "value3":
+                    jsonFieldCounter0++;
+
+                    Double value_value3 = getDoubleSafely(in);
+                    if (value_value3 != null) {
+                        result.value3 = value_value3;
+                    }
+                    break;
+
+                default:
+                    in.skipValue();
+                    break;
+            }
+        }
+
+        in.endObject();
+        return result;
+    }
+
+    @Override
+    public void write(JsonWriter out, GenericsTest value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+            return;
+        }
+
+        // Begin
+        out.beginObject();
+        String obj0 = value.value1;
+        if (obj0 != null) {
+            out.name("value1");
+            out.value(obj0);
+        }
+
+        Map<String, Integer> obj1 = value.value2;
+        if (obj1 != null) {
+            out.name("value2");
+            mGson.getAdapter(new com.google.gson.reflect.TypeToken<java.util.Map<java.lang.String, java.lang.Integer>>(){}).write(out, obj1);
+        }
+
+        Double obj2 = value.value3;
+        if (obj2 != null) {
+            out.name("value3");
+            out.value(obj2);
+        }
+
+        // End
+        out.endObject();
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/classes/IntermediateTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/classes/IntermediateTest.java
@@ -1,0 +1,5 @@
+package adapter.auto.generics.classes;
+
+class IntermediateTest<T, V> extends BaseTest<T, String, Integer> {
+    V value3;
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/BaseTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/BaseTest.java
@@ -1,0 +1,10 @@
+package adapter.auto.generics.interfaces;
+
+import java.util.List;
+import java.util.Map;
+
+interface BaseTest<GENERIC_1, GENERIC_2, GENERIC_3> {
+    GENERIC_1 getValue1();
+
+    Map<GENERIC_2, GENERIC_3> getValue2();
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/GenericsTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/GenericsTest.java
@@ -1,0 +1,7 @@
+package adapter.auto.generics.interfaces;
+
+import gsonpath.AutoGsonAdapter;
+
+@AutoGsonAdapter
+interface GenericsTest extends IntermediateTest<String, Double> {
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/GenericsTest_GsonPathModel.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/GenericsTest_GsonPathModel.java
@@ -1,0 +1,68 @@
+package adapter.auto.generics.interfaces;
+
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.Object;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Map;
+
+public final class GenericsTest_GsonPathModel implements GenericsTest {
+    private final String value1;
+
+    private final Map<String, Integer> value2;
+
+    private final Double value3;
+
+    public GenericsTest_GsonPathModel(String value1, Map<String, Integer> value2, Double value3) {
+        this.value1 = value1;
+        this.value2 = value2;
+        this.value3 = value3;
+    }
+
+    @Override
+    public String getValue1() {
+        return value1;
+    }
+
+    @Override
+    public Map<String, Integer> getValue2() {
+        return value2;
+    }
+
+    @Override
+    public Double getValue3() {
+        return value3;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GenericsTest_GsonPathModel that = (GenericsTest_GsonPathModel) o;
+
+        if (value1 != null ? !value1.equals(that.value1) : that.value1 != null) return false;
+        if (value2 != null ? !value2.equals(that.value2) : that.value2 != null) return false;
+        if (value3 != null ? !value3.equals(that.value3) : that.value3 != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = value1 != null ? value1.hashCode() : 0;
+        result = 31 * result + (value2 != null ? value2.hashCode() : 0);
+        result = 31 * result + (value3 != null ? value3.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GenericsTest{" +
+                "value1=" + value1 +
+                ", value2=" + value2 +
+                ", value3=" + value3 +
+                '}';
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/GenericsTest_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/GenericsTest_GsonTypeAdapter.java
@@ -1,0 +1,74 @@
+package adapter.auto.generics.interfaces;
+
+import static gsonpath.GsonUtil.*;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.Override;
+
+public final class GenericsTest_GsonTypeAdapter extends TypeAdapter<GenericsTest> {
+    private final Gson mGson;
+
+    public GenericsTest_GsonTypeAdapter(Gson gson) {
+        this.mGson = gson;
+    }
+
+    @Override
+    public GenericsTest read(JsonReader in) throws IOException {
+        // Ensure the object is not null.
+        if (!isValidValue(in)) {
+            return null;
+        }
+        java.lang.String value_value1 = null;
+        java.util.Map<java.lang.String, java.lang.Integer> value_value2 = null;
+        java.lang.Double value_value3 = null;
+
+        int jsonFieldCounter0 = 0;
+        in.beginObject();
+
+        while (in.hasNext()) {
+            if (jsonFieldCounter0 == 3) {
+                in.skipValue();
+                continue;
+            }
+
+            switch (in.nextName()) {
+                case "value1":
+                    jsonFieldCounter0++;
+
+                    value_value1 = getStringSafely(in);
+                    break;
+
+                case "value2":
+                    jsonFieldCounter0++;
+
+                    value_value2 = mGson.getAdapter(new com.google.gson.reflect.TypeToken<java.util.Map<java.lang.String, java.lang.Integer>>(){}).read(in);
+                    break;
+
+                case "value3":
+                    jsonFieldCounter0++;
+
+                    value_value3 = getDoubleSafely(in);
+                    break;
+
+                default:
+                    in.skipValue();
+                    break;
+            }
+        }
+
+        in.endObject();
+        return new GenericsTest_GsonPathModel(
+                value_value1,
+                value_value2,
+                value_value3
+        );
+    }
+
+    @Override
+    public void write(JsonWriter out, GenericsTest value) throws IOException {
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/IntermediateTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces/IntermediateTest.java
@@ -1,0 +1,5 @@
+package adapter.auto.generics.interfaces;
+
+interface IntermediateTest<T, V> extends BaseTest<T, String, Integer> {
+    V getValue3();
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces_and_classs/BaseTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces_and_classs/BaseTest.java
@@ -1,0 +1,9 @@
+package adapter.auto.generics.interfaces_and_classs;
+
+import java.util.Map;
+
+interface BaseTest<GENERIC_1, GENERIC_2, GENERIC_3> {
+    GENERIC_1 getValue1();
+
+    Map<GENERIC_2, GENERIC_3> getValue2();
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces_and_classs/GenericsTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces_and_classs/GenericsTest.java
@@ -1,0 +1,13 @@
+package adapter.auto.generics.interfaces_and_classs;
+
+import gsonpath.AutoGsonAdapter;
+
+@AutoGsonAdapter
+class GenericsTest extends IntermediateTest<String, Double> {
+    Double value3;
+
+    @Override
+    public Double getValue3() {
+        return value3;
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces_and_classs/GenericsTest_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces_and_classs/GenericsTest_GsonTypeAdapter.java
@@ -1,0 +1,108 @@
+package adapter.auto.generics.interfaces_and_classs;
+
+import static gsonpath.GsonUtil.*;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.lang.Double;
+import java.lang.Integer;
+import java.lang.Override;
+import java.lang.String;
+import java.util.Map;
+
+public final class GenericsTest_GsonTypeAdapter extends TypeAdapter<GenericsTest> {
+    private final Gson mGson;
+
+    public GenericsTest_GsonTypeAdapter(Gson gson) {
+        this.mGson = gson;
+    }
+
+    @Override
+    public GenericsTest read(JsonReader in) throws IOException {
+        // Ensure the object is not null.
+        if (!isValidValue(in)) {
+            return null;
+        }
+        GenericsTest result = new GenericsTest();
+
+        int jsonFieldCounter0 = 0;
+        in.beginObject();
+
+        while (in.hasNext()) {
+            if (jsonFieldCounter0 == 3) {
+                in.skipValue();
+                continue;
+            }
+
+            switch (in.nextName()) {
+                case "value1":
+                    jsonFieldCounter0++;
+
+                    String value_value1 = getStringSafely(in);
+                    if (value_value1 != null) {
+                        result.value1 = value_value1;
+                    }
+                    break;
+
+                case "value2":
+                    jsonFieldCounter0++;
+
+                    java.util.Map<java.lang.String, java.lang.Integer> value_value2 = mGson.getAdapter(new com.google.gson.reflect.TypeToken<java.util.Map<java.lang.String, java.lang.Integer>>(){}).read(in);
+                    if (value_value2 != null) {
+                        result.value2 = value_value2;
+                    }
+                    break;
+
+                case "value3":
+                    jsonFieldCounter0++;
+
+                    Double value_value3 = getDoubleSafely(in);
+                    if (value_value3 != null) {
+                        result.value3 = value_value3;
+                    }
+                    break;
+
+                default:
+                    in.skipValue();
+                    break;
+            }
+        }
+
+        in.endObject();
+        return result;
+    }
+
+    @Override
+    public void write(JsonWriter out, GenericsTest value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+            return;
+        }
+
+        // Begin
+        out.beginObject();
+        String obj0 = value.value1;
+        if (obj0 != null) {
+            out.name("value1");
+            out.value(obj0);
+        }
+
+        Map<String, Integer> obj1 = value.value2;
+        if (obj1 != null) {
+            out.name("value2");
+            mGson.getAdapter(new com.google.gson.reflect.TypeToken<java.util.Map<java.lang.String, java.lang.Integer>>(){}).write(out, obj1);
+        }
+
+        Double obj2 = value.value3;
+        if (obj2 != null) {
+            out.name("value3");
+            out.value(obj2);
+        }
+
+        // End
+        out.endObject();
+    }
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces_and_classs/IntermediateTest.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/generics/interfaces_and_classs/IntermediateTest.java
@@ -1,0 +1,20 @@
+package adapter.auto.generics.interfaces_and_classs;
+
+import java.util.Map;
+
+abstract class IntermediateTest<T, V> implements BaseTest<T, String, Integer> {
+    T value1;
+    Map<String, Integer> value2;
+
+    @Override
+    public T getValue1() {
+        return value1;
+    }
+
+    @Override
+    public Map<String, Integer> getValue2() {
+        return value2;
+    }
+
+    public abstract V getValue3();
+}


### PR DESCRIPTION
Fixed an issue which was causing generics to not function as expected.

This PR relates to issue #69.

It should now be possible to use any combination of inheritance, multiple interfaces, abstract classes and standard class inheritance.

The following should now function correctly:

```
interface ApiResponse<T> {
  List<T> getResult();
}
```

```
@AutoGsonAdapter
interface UserApiResponse extends ApiResponse<User> {

}
```