### PR TITLE
Issue-78 Added a 'failure outcome' to GsonSubType

### DIFF
--- a/gsonpath-compiler/src/test/java/gsonpath/generator/adapter/auto/PolymorphismTest.kt
+++ b/gsonpath-compiler/src/test/java/gsonpath/generator/adapter/auto/PolymorphismTest.kt
@@ -63,29 +63,66 @@ class PolymorphismTest : BaseGeneratorTest() {
     }
 
     @Test
+    fun givenDefaultValueAndDefaultFailureOutcome_whenProcessorExecuted_expectValidGsonTypeAdapter() {
+        assertGeneratedContent(BaseGeneratorTest.TestCriteria("adapter/auto/polymorphism/default_value")
+                .addAbsoluteSource("adapter/auto/TestGsonTypeFactory.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type1.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type2.java")
+                .addRelativeSource("TypesList.java")
+                .addRelativeGenerated("TypesList_GsonTypeAdapter.java"))
+    }
+
+    @Test
+    fun givenRemoveElementFailureOutcome_whenProcessorExecuted_expectValidGsonTypeAdapter() {
+        assertGeneratedContent(BaseGeneratorTest.TestCriteria("adapter/auto/polymorphism/failure_outcome_remove_element")
+                .addAbsoluteSource("adapter/auto/TestGsonTypeFactory.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type1.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type2.java")
+                .addRelativeSource("TypesList.java")
+                .addRelativeGenerated("TypesList_GsonTypeAdapter.java"))
+    }
+
+    @Test
+    fun givenFailFailureOutcome_whenProcessorExecuted_expectValidGsonTypeAdapter() {
+        assertGeneratedContent(BaseGeneratorTest.TestCriteria("adapter/auto/polymorphism/failure_outcome_fail")
+                .addAbsoluteSource("adapter/auto/TestGsonTypeFactory.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type1.java")
+                .addAbsoluteSource("adapter/auto/polymorphism/Type2.java")
+                .addRelativeSource("TypesList.java")
+                .addRelativeGenerated("TypesList_GsonTypeAdapter.java"))
+    }
+
+    @Test
     fun givenNoKeys_whenProcessorExecuted_expectNoKeysError() {
-        assertPolymorphismFailure("no_keys", "Gson Path: Keys must be specified for the GsonSubType")
+        assertPolymorphismFailure("TypesList_NoKeys.java",
+                "Gson Path: Keys must be specified for the GsonSubType")
     }
 
     @Test
     fun givenMultipleKeys_whenProcessorExecuted_expectMultipleKeysError() {
-        assertPolymorphismFailure("multiple_keys", "Only one keys array (string, integer or boolean) may be specified for the GsonSubType")
+        assertPolymorphismFailure("TypesList_MultipleKeys.java",
+                "Only one keys array (string, integer or boolean) may be specified for the GsonSubType")
     }
 
     @Test
     fun givenBlankFieldName_whenProcessorExecuted_expectBlankFieldNameError() {
-        assertPolymorphismFailure("blank_field", "Gson Path: fieldName cannot be blank for GsonSubType")
+        assertPolymorphismFailure("TypesList_BlankFieldName.java",
+                "Gson Path: fieldName cannot be blank for GsonSubType")
     }
 
     @Test
     fun givenNoInheritanceLink_whenProcessorExecuted_expectBlankFieldNameError() {
-        assertPolymorphismFailure("type_no_inheritance", "Gson Path: subtype java.lang.String does not inherit from adapter.auto.polymorphism.Type")
+        assertPolymorphismFailure("TypesList_TypeInvalidInheritance.java",
+                "Gson Path: subtype java.lang.String does not inherit from adapter.auto.polymorphism.Type")
     }
 
-    private fun assertPolymorphismFailure(directoryName: String, errorMessage: String) {
-        val criteria = BaseGeneratorTest.TestCriteria("adapter/auto/polymorphism/$directoryName")
+    private fun assertPolymorphismFailure(className: String, errorMessage: String) {
+        val criteria = BaseGeneratorTest.TestCriteria("adapter/auto/polymorphism/failures")
                 .addAbsoluteSource("adapter/auto/TestGsonTypeFactory.java")
-                .addRelativeSource("TypesList.java")
+                .addRelativeSource(className)
 
         val sourceFilesSize = criteria.sourceFilesSize
         val sources = (0..sourceFilesSize - 1).map { criteria.getSourceFileObject(it) }

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/boolean_keys/TypesList_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/boolean_keys/TypesList_GsonTypeAdapter.java
@@ -84,7 +84,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
     private StrictArrayTypeAdapter getItemsGsonSubtype() {
         if (itemsGsonSubtype == null) {
-            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class);
+            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class, false);
         }
         return itemsGsonSubtype;
     }
@@ -117,7 +117,8 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
             if (delegate == null) {
                 return null;
             }
-            return delegate.fromJsonTree(jsonElement);
+            adapter.auto.polymorphism.Type result = delegate.fromJsonTree(jsonElement);
+            return result;
         }
 
         @Override

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/default_value/TypesList.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/default_value/TypesList.java
@@ -1,0 +1,22 @@
+package adapter.auto.polymorphism.default_value;
+
+import gsonpath.AutoGsonAdapter;
+import gsonpath.GsonSubTypeFailureOutcome;
+import gsonpath.GsonSubtype;
+
+import adapter.auto.polymorphism.Type;
+import adapter.auto.polymorphism.Type1;
+import adapter.auto.polymorphism.Type2;
+
+@AutoGsonAdapter
+class TypesList {
+    @GsonSubtype(
+            fieldName = "type",
+            subTypeFailureOutcome = GsonSubTypeFailureOutcome.NULL_OR_DEFAULT_VALUE,
+            defaultType = Type2.class,
+            stringKeys = {
+                    @GsonSubtype.StringKey(key = "type1", subtype = Type1.class)
+            }
+    )
+    Type[] items;
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/default_value/TypesList_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/default_value/TypesList_GsonTypeAdapter.java
@@ -1,4 +1,4 @@
-package adapter.auto.polymorphism.using_list;
+package adapter.auto.polymorphism.default_value;
 
 import static gsonpath.GsonUtil.*;
 
@@ -10,18 +10,17 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import gsonpath.internal.CollectionTypeAdapter;
+import gsonpath.internal.StrictArrayTypeAdapter;
 import java.io.IOException;
 import java.lang.Class;
 import java.lang.Override;
 import java.lang.String;
-import java.util.List;
 import java.util.Map;
 
 public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
     private final Gson mGson;
 
-    private CollectionTypeAdapter<Type> itemsGsonSubtype;
+    private StrictArrayTypeAdapter itemsGsonSubtype;
 
     public TypesList_GsonTypeAdapter(Gson gson) {
         this.mGson = gson;
@@ -48,7 +47,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
                 case "items":
                     jsonFieldCounter0++;
 
-                    java.util.List<adapter.auto.polymorphism.Type> value_items = (java.util.List<adapter.auto.polymorphism.Type>) getItemsGsonSubtype().read(in);
+                    adapter.auto.polymorphism.Type[] value_items = (adapter.auto.polymorphism.Type[]) getItemsGsonSubtype().read(in);
                     if (value_items != null) {
                         result.items = value_items;
                     }
@@ -73,7 +72,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
         // Begin
         out.beginObject();
-        List<Type> obj0 = value.items;
+        Type[] obj0 = value.items;
         if (obj0 != null) {
             out.name("items");
             getItemsGsonSubtype().write(out, obj0);
@@ -83,9 +82,9 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
         out.endObject();
     }
 
-    private CollectionTypeAdapter<Type> getItemsGsonSubtype() {
+    private StrictArrayTypeAdapter getItemsGsonSubtype() {
         if (itemsGsonSubtype == null) {
-            itemsGsonSubtype = new CollectionTypeAdapter<Type>(new ItemsGsonSubtype(mGson), false);
+            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class, false);
         }
         return itemsGsonSubtype;
     }
@@ -95,15 +94,15 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
         private final Map<Class<? extends Type>, TypeAdapter<? extends Type>> typeAdaptersDelegatedByClassMap;
 
+        private final TypeAdapter<? extends Type> defaultTypeAdapterDelegate;
+
         private ItemsGsonSubtype(Gson gson) {
             typeAdaptersDelegatedByValueMap = new java.util.HashMap<>();
             typeAdaptersDelegatedByClassMap = new java.util.HashMap<>();
 
             typeAdaptersDelegatedByValueMap.put("type1", gson.getAdapter(adapter.auto.polymorphism.Type1.class));
             typeAdaptersDelegatedByClassMap.put(adapter.auto.polymorphism.Type1.class, gson.getAdapter(adapter.auto.polymorphism.Type1.class));
-
-            typeAdaptersDelegatedByValueMap.put("type2", gson.getAdapter(adapter.auto.polymorphism.Type2.class));
-            typeAdaptersDelegatedByClassMap.put(adapter.auto.polymorphism.Type2.class, gson.getAdapter(adapter.auto.polymorphism.Type2.class));
+            defaultTypeAdapterDelegate = gson.getAdapter(adapter.auto.polymorphism.Type2.class);
         }
 
         @Override
@@ -116,7 +115,8 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
             java.lang.String value = typeValueJsonElement.getAsString();
             TypeAdapter<? extends adapter.auto.polymorphism.Type> delegate = typeAdaptersDelegatedByValueMap.get(value);
             if (delegate == null) {
-                return null;
+                // Use the default type adapter if the type is unknown.
+                delegate = defaultTypeAdapterDelegate;
             }
             adapter.auto.polymorphism.Type result = delegate.fromJsonTree(jsonElement);
             return result;
@@ -129,6 +129,10 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
                 return;
             }
             TypeAdapter delegate = typeAdaptersDelegatedByClassMap.get(value.getClass());
+            if (delegate == null) {
+                // Use the default type adapter if the type is unknown.
+                delegate = defaultTypeAdapterDelegate;
+            }
             delegate.write(out, value);
         }
     }

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/duplicate_keys/TypesList_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/duplicate_keys/TypesList_GsonTypeAdapter.java
@@ -84,7 +84,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
     private StrictArrayTypeAdapter getItemsGsonSubtype() {
         if (itemsGsonSubtype == null) {
-            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class);
+            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class, false);
         }
         return itemsGsonSubtype;
     }
@@ -117,7 +117,8 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
             if (delegate == null) {
                 return null;
             }
-            return delegate.fromJsonTree(jsonElement);
+            adapter.auto.polymorphism.Type result = delegate.fromJsonTree(jsonElement);
+            return result;
         }
 
         @Override

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failure_outcome_fail/TypesList.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failure_outcome_fail/TypesList.java
@@ -1,0 +1,22 @@
+package adapter.auto.polymorphism.string_keys;
+
+import gsonpath.AutoGsonAdapter;
+import gsonpath.GsonSubTypeFailureOutcome;
+import gsonpath.GsonSubtype;
+
+import adapter.auto.polymorphism.Type;
+import adapter.auto.polymorphism.Type1;
+import adapter.auto.polymorphism.Type2;
+
+@AutoGsonAdapter
+class TypesList {
+    @GsonSubtype(
+            fieldName = "type",
+            subTypeFailureOutcome = GsonSubTypeFailureOutcome.FAIL,
+            stringKeys = {
+                    @GsonSubtype.StringKey(key = "type1", subtype = Type1.class),
+                    @GsonSubtype.StringKey(key = "type2", subtype = Type2.class)
+            }
+    )
+    Type[] items;
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failure_outcome_fail/TypesList_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failure_outcome_fail/TypesList_GsonTypeAdapter.java
@@ -1,4 +1,4 @@
-package adapter.auto.polymorphism.using_list;
+package adapter.auto.polymorphism.string_keys;
 
 import static gsonpath.GsonUtil.*;
 
@@ -10,18 +10,19 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import gsonpath.internal.CollectionTypeAdapter;
+import gsonpath.GsonSubTypeFailureException;
+import gsonpath.internal.StrictArrayTypeAdapter;
+
 import java.io.IOException;
 import java.lang.Class;
 import java.lang.Override;
 import java.lang.String;
-import java.util.List;
 import java.util.Map;
 
 public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
     private final Gson mGson;
 
-    private CollectionTypeAdapter<Type> itemsGsonSubtype;
+    private StrictArrayTypeAdapter itemsGsonSubtype;
 
     public TypesList_GsonTypeAdapter(Gson gson) {
         this.mGson = gson;
@@ -48,7 +49,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
                 case "items":
                     jsonFieldCounter0++;
 
-                    java.util.List<adapter.auto.polymorphism.Type> value_items = (java.util.List<adapter.auto.polymorphism.Type>) getItemsGsonSubtype().read(in);
+                    adapter.auto.polymorphism.Type[] value_items = (adapter.auto.polymorphism.Type[]) getItemsGsonSubtype().read(in);
                     if (value_items != null) {
                         result.items = value_items;
                     }
@@ -73,7 +74,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
         // Begin
         out.beginObject();
-        List<Type> obj0 = value.items;
+        Type[] obj0 = value.items;
         if (obj0 != null) {
             out.name("items");
             getItemsGsonSubtype().write(out, obj0);
@@ -83,9 +84,9 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
         out.endObject();
     }
 
-    private CollectionTypeAdapter<Type> getItemsGsonSubtype() {
+    private StrictArrayTypeAdapter getItemsGsonSubtype() {
         if (itemsGsonSubtype == null) {
-            itemsGsonSubtype = new CollectionTypeAdapter<Type>(new ItemsGsonSubtype(mGson), false);
+            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class, false);
         }
         return itemsGsonSubtype;
     }
@@ -116,9 +117,12 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
             java.lang.String value = typeValueJsonElement.getAsString();
             TypeAdapter<? extends adapter.auto.polymorphism.Type> delegate = typeAdaptersDelegatedByValueMap.get(value);
             if (delegate == null) {
-                return null;
+                throw new GsonSubTypeFailureException("Failed to find subtype for value: " + value);
             }
             adapter.auto.polymorphism.Type result = delegate.fromJsonTree(jsonElement);
+            if (result == null) {
+                throw new GsonSubTypeFailureException("Failed to deserailize subtype for object: " + jsonElement);
+            }
             return result;
         }
 

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failure_outcome_remove_element/TypesList.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failure_outcome_remove_element/TypesList.java
@@ -1,0 +1,22 @@
+package adapter.auto.polymorphism.string_keys;
+
+import gsonpath.AutoGsonAdapter;
+import gsonpath.GsonSubTypeFailureOutcome;
+import gsonpath.GsonSubtype;
+
+import adapter.auto.polymorphism.Type;
+import adapter.auto.polymorphism.Type1;
+import adapter.auto.polymorphism.Type2;
+
+@AutoGsonAdapter
+class TypesList {
+    @GsonSubtype(
+            fieldName = "type",
+            subTypeFailureOutcome = GsonSubTypeFailureOutcome.REMOVE_ELEMENT,
+            stringKeys = {
+                    @GsonSubtype.StringKey(key = "type1", subtype = Type1.class),
+                    @GsonSubtype.StringKey(key = "type2", subtype = Type2.class)
+            }
+    )
+    Type[] items;
+}

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failure_outcome_remove_element/TypesList_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failure_outcome_remove_element/TypesList_GsonTypeAdapter.java
@@ -1,4 +1,4 @@
-package adapter.auto.polymorphism.using_list;
+package adapter.auto.polymorphism.string_keys;
 
 import static gsonpath.GsonUtil.*;
 
@@ -10,18 +10,17 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import gsonpath.internal.CollectionTypeAdapter;
+import gsonpath.internal.StrictArrayTypeAdapter;
 import java.io.IOException;
 import java.lang.Class;
 import java.lang.Override;
 import java.lang.String;
-import java.util.List;
 import java.util.Map;
 
 public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
     private final Gson mGson;
 
-    private CollectionTypeAdapter<Type> itemsGsonSubtype;
+    private StrictArrayTypeAdapter itemsGsonSubtype;
 
     public TypesList_GsonTypeAdapter(Gson gson) {
         this.mGson = gson;
@@ -48,7 +47,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
                 case "items":
                     jsonFieldCounter0++;
 
-                    java.util.List<adapter.auto.polymorphism.Type> value_items = (java.util.List<adapter.auto.polymorphism.Type>) getItemsGsonSubtype().read(in);
+                    adapter.auto.polymorphism.Type[] value_items = (adapter.auto.polymorphism.Type[]) getItemsGsonSubtype().read(in);
                     if (value_items != null) {
                         result.items = value_items;
                     }
@@ -73,7 +72,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
         // Begin
         out.beginObject();
-        List<Type> obj0 = value.items;
+        Type[] obj0 = value.items;
         if (obj0 != null) {
             out.name("items");
             getItemsGsonSubtype().write(out, obj0);
@@ -83,9 +82,9 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
         out.endObject();
     }
 
-    private CollectionTypeAdapter<Type> getItemsGsonSubtype() {
+    private StrictArrayTypeAdapter getItemsGsonSubtype() {
         if (itemsGsonSubtype == null) {
-            itemsGsonSubtype = new CollectionTypeAdapter<Type>(new ItemsGsonSubtype(mGson), false);
+            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class, true);
         }
         return itemsGsonSubtype;
     }

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failures/TypesList_BlankFieldName.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failures/TypesList_BlankFieldName.java
@@ -1,11 +1,11 @@
-package adapter.auto.polymorphism.blank_field;
+package adapter.auto.polymorphism.failures;
 
 import adapter.auto.polymorphism.Type1;
 import gsonpath.AutoGsonAdapter;
 import gsonpath.GsonSubtype;
 
 @AutoGsonAdapter
-class TypesList {
+class TypesList_BlankFieldName {
     @GsonSubtype(
             fieldName = "",
             stringKeys = {

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failures/TypesList_MultipleKeys.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failures/TypesList_MultipleKeys.java
@@ -1,11 +1,11 @@
-package adapter.auto.polymorphism.multiple_keys;
+package adapter.auto.polymorphism.failures;
 
 import adapter.auto.polymorphism.Type1;
 import gsonpath.AutoGsonAdapter;
 import gsonpath.GsonSubtype;
 
 @AutoGsonAdapter
-class TypesList {
+class TypesList_MultipleKeys {
     @GsonSubtype(
             fieldName = "type",
             stringKeys = {

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failures/TypesList_NoKeys.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failures/TypesList_NoKeys.java
@@ -1,10 +1,10 @@
-package adapter.auto.polymorphism.no_keys;
+package adapter.auto.polymorphism.failures;
 
 import gsonpath.AutoGsonAdapter;
 import gsonpath.GsonSubtype;
 
 @AutoGsonAdapter
-class TypesList {
+class TypesList_NoKeys {
     @GsonSubtype(
             fieldName = "type"
     )

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failures/TypesList_TypeInvalidInheritance.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/failures/TypesList_TypeInvalidInheritance.java
@@ -1,4 +1,4 @@
-package adapter.auto.polymorphism.type_no_inheritance;
+package adapter.auto.polymorphism.failures;
 
 import java.lang.String;
 
@@ -8,7 +8,7 @@ import gsonpath.AutoGsonAdapter;
 import gsonpath.GsonSubtype;
 
 @AutoGsonAdapter
-class TypesList {
+class TypesList_TypeInvalidInheritance {
     @GsonSubtype(
             fieldName = "type",
             stringKeys = {

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/integer_keys/TypesList_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/integer_keys/TypesList_GsonTypeAdapter.java
@@ -84,7 +84,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
     private StrictArrayTypeAdapter getItemsGsonSubtype() {
         if (itemsGsonSubtype == null) {
-            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class);
+            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class, false);
         }
         return itemsGsonSubtype;
     }
@@ -117,7 +117,8 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
             if (delegate == null) {
                 return null;
             }
-            return delegate.fromJsonTree(jsonElement);
+            adapter.auto.polymorphism.Type result = delegate.fromJsonTree(jsonElement);
+            return result;
         }
 
         @Override

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/string_keys/TypesList_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/string_keys/TypesList_GsonTypeAdapter.java
@@ -84,7 +84,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
     private StrictArrayTypeAdapter getItemsGsonSubtype() {
         if (itemsGsonSubtype == null) {
-            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class);
+            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class, false);
         }
         return itemsGsonSubtype;
     }
@@ -117,7 +117,8 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
             if (delegate == null) {
                 return null;
             }
-            return delegate.fromJsonTree(jsonElement);
+            adapter.auto.polymorphism.Type result = delegate.fromJsonTree(jsonElement);
+            return result;
         }
 
         @Override

--- a/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/using_interface/TypesList_GsonTypeAdapter.java
+++ b/gsonpath-compiler/src/test/resources/adapter/auto/polymorphism/using_interface/TypesList_GsonTypeAdapter.java
@@ -68,7 +68,7 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
 
     private StrictArrayTypeAdapter getItemsGsonSubtype() {
         if (itemsGsonSubtype == null) {
-            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class);
+            itemsGsonSubtype = new StrictArrayTypeAdapter<>(new ItemsGsonSubtype(mGson), Type.class, false);
         }
         return itemsGsonSubtype;
     }
@@ -101,7 +101,8 @@ public final class TypesList_GsonTypeAdapter extends TypeAdapter<TypesList> {
             if (delegate == null) {
                 return null;
             }
-            return delegate.fromJsonTree(jsonElement);
+            adapter.auto.polymorphism.Type result = delegate.fromJsonTree(jsonElement);
+            return result;
         }
 
         @Override

--- a/gsonpath/src/main/java/gsonpath/GsonSubTypeFailureException.java
+++ b/gsonpath/src/main/java/gsonpath/GsonSubTypeFailureException.java
@@ -1,0 +1,14 @@
+package gsonpath;
+
+import com.google.gson.JsonParseException;
+
+/**
+ * An exception which is fired when a {@link GsonSubtype} annotated field using the
+ * {@link GsonSubtype#subTypeFailureOutcome()} of {@link GsonSubTypeFailureOutcome#FAIL} fails to correctly
+ * deserialize a Json Object.
+ */
+public class GsonSubTypeFailureException extends JsonParseException {
+    public GsonSubTypeFailureException(String message) {
+        super(message);
+    }
+}

--- a/gsonpath/src/main/java/gsonpath/GsonSubTypeFailureOutcome.java
+++ b/gsonpath/src/main/java/gsonpath/GsonSubTypeFailureOutcome.java
@@ -1,0 +1,27 @@
+package gsonpath;
+
+/**
+ * Defines the outcome of the GsonSubType generated code when the subtype is not found, either because an unexpected
+ * subtype was found, or the delegated type adapter returned null.
+ */
+public enum GsonSubTypeFailureOutcome {
+    /**
+     * When an unexpected subtype is found, the value within the array will depend on whether the
+     * {@link GsonSubtype#defaultType()} is specified. If it is not, a null value will always be assigned.
+     * If the default type is supplied, this will be delegated to.
+     * <p>
+     * Note: A null value may still be returned if the default type cannot deserialize the object.
+     */
+    NULL_OR_DEFAULT_VALUE,
+
+    /**
+     * When an unexpected subtype is found, the element will be removed from the array / collection
+     */
+    REMOVE_ELEMENT,
+
+    /**
+     * When an unexpected subtype is found, an exception will be thrown, and the {@link com.google.gson.TypeAdapter}
+     * will stop prematurely.
+     */
+    FAIL
+}

--- a/gsonpath/src/main/java/gsonpath/GsonSubtype.java
+++ b/gsonpath/src/main/java/gsonpath/GsonSubtype.java
@@ -22,11 +22,21 @@ public @interface GsonSubtype {
     String fieldName();
 
     /**
-     * Whether the TypeAdapter should throw an exception when an unexpected type is found.
+     * Determines the behaviour of the generated subtype adapter when an unknown subtype is found, or the subtype
+     * fails to be deserailized (i.e. it returns a null value)
      *
-     * @return true if the TypeAdapter should throw an exception.
+     * @return the enum value which defines the outcome.
      */
-    boolean failOnMissingKey() default false;
+    GsonSubTypeFailureOutcome subTypeFailureOutcome() default GsonSubTypeFailureOutcome.NULL_OR_DEFAULT_VALUE;
+
+    /**
+     * The default type that is used if an unexpected key is encountered.
+     * Note: This will only be used if {@link #subTypeFailureOutcome} is set to
+     * {@link GsonSubTypeFailureOutcome#NULL_OR_DEFAULT_VALUE}
+     *
+     * @return the fall-back type to use.
+     */
+    Class defaultType() default void.class;
 
     /**
      * An array of string keys and their related subtype class, this may be empty, however one of the 'keys' arrays

--- a/gsonpath/src/main/java/gsonpath/internal/CollectionTypeAdapter.java
+++ b/gsonpath/src/main/java/gsonpath/internal/CollectionTypeAdapter.java
@@ -18,9 +18,11 @@ import java.util.List;
  */
 public final class CollectionTypeAdapter<E> extends TypeAdapter<Collection<E>> {
     private final TypeAdapter<E> componentTypeAdapter;
+    private boolean filterNulls;
 
-    public CollectionTypeAdapter(TypeAdapter<E> componentTypeAdapter) {
+    public CollectionTypeAdapter(TypeAdapter<E> componentTypeAdapter, boolean filterNulls) {
         this.componentTypeAdapter = componentTypeAdapter;
+        this.filterNulls = filterNulls;
     }
 
     @Override
@@ -34,6 +36,11 @@ public final class CollectionTypeAdapter<E> extends TypeAdapter<Collection<E>> {
         in.beginArray();
         while (in.hasNext()) {
             E instance = componentTypeAdapter.read(in);
+
+            if (filterNulls && instance == null) {
+                continue;
+            }
+
             list.add(instance);
         }
         in.endArray();

--- a/gsonpath/src/main/java/gsonpath/internal/StrictArrayTypeAdapter.java
+++ b/gsonpath/src/main/java/gsonpath/internal/StrictArrayTypeAdapter.java
@@ -19,11 +19,13 @@ import java.util.List;
  */
 public final class StrictArrayTypeAdapter<E> extends TypeAdapter<Object> {
     private final Class<E> componentType;
+    private final boolean filterNulls;
     private final TypeAdapter<E> componentTypeAdapter;
 
-    public StrictArrayTypeAdapter(TypeAdapter<E> componentTypeAdapter, Class<E> componentType) {
+    public StrictArrayTypeAdapter(TypeAdapter<E> componentTypeAdapter, Class<E> componentType, boolean filterNulls) {
         this.componentTypeAdapter = componentTypeAdapter;
         this.componentType = componentType;
+        this.filterNulls = filterNulls;
     }
 
     @Override
@@ -37,6 +39,11 @@ public final class StrictArrayTypeAdapter<E> extends TypeAdapter<Object> {
         in.beginArray();
         while (in.hasNext()) {
             E instance = componentTypeAdapter.read(in);
+
+            if (filterNulls && instance == null) {
+                continue;
+            }
+
             list.add(instance);
         }
         in.endArray();


### PR DESCRIPTION
Introduced a 'failure outcome' feature which allows the developer to decide how the parser should react with an unknown subtype, or a subtype that fails to be deserialized.

These outcomes are as follows:

- NULL_OR_DEFAULT_VALUE
   _When an unexpected subtype is found, the value within the array will depend on whether the GsonSubtype defaultType is specified. If it is not, a null value will always be assigned.
   If the default type is supplied, this will be delegated to._

   _Note: A null value may still be returned if the default type cannot deserialize the object._

- REMOVE_ELEMENT
   _When an unexpected subtype is found, the element will be removed from the array / collection_

- FAIL
   _When an unexpected subtype is found, an exception will be thrown, and the TypeAdapter will stop prematurely._