### PR TITLE
Handling empty string in Number type

### DIFF
--- a/gsonpath/build.gradle
+++ b/gsonpath/build.gradle
@@ -11,6 +11,9 @@ sourceCompatibility = JavaVersion.VERSION_1_7
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile "com.google.code.gson:gson:$gson_version"
+
+    testCompile "junit:junit:$junit_version"
+    testCompile "org.mockito:mockito-core:1.10.19"
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {

--- a/gsonpath/src/main/java/gsonpath/GsonUtil.java
+++ b/gsonpath/src/main/java/gsonpath/GsonUtil.java
@@ -72,7 +72,11 @@ public class GsonUtil {
     @SuppressWarnings("unused")
     public static Integer getIntegerSafely(JsonReader in) throws IOException {
         if (isValidValue(in)) {
-            return in.nextInt();
+            try {
+                return in.nextInt();
+            } catch (NumberFormatException ignored) {
+                // Fall back to return null
+            }
         }
         return null;
     }
@@ -88,7 +92,11 @@ public class GsonUtil {
     @SuppressWarnings("unused")
     public static Long getLongSafely(JsonReader in) throws IOException {
         if (isValidValue(in)) {
-            return in.nextLong();
+            try {
+                return in.nextLong();
+            } catch (NumberFormatException ignored) {
+                // Fall back to return null
+            }
         }
         return null;
     }
@@ -104,7 +112,11 @@ public class GsonUtil {
     @SuppressWarnings("unused")
     public static Double getDoubleSafely(JsonReader in) throws IOException {
         if (isValidValue(in)) {
-            return in.nextDouble();
+            try {
+                return in.nextDouble();
+            } catch (NumberFormatException ignored) {
+                // Fall back to return null
+            }
         }
         return null;
     }

--- a/gsonpath/src/main/java/gsonpath/GsonUtil.java
+++ b/gsonpath/src/main/java/gsonpath/GsonUtil.java
@@ -76,6 +76,7 @@ public class GsonUtil {
                 return in.nextInt();
             } catch (NumberFormatException ignored) {
                 // Fall back to return null
+                in.skipValue();
             }
         }
         return null;
@@ -96,6 +97,7 @@ public class GsonUtil {
                 return in.nextLong();
             } catch (NumberFormatException ignored) {
                 // Fall back to return null
+                in.skipValue();
             }
         }
         return null;
@@ -116,6 +118,7 @@ public class GsonUtil {
                 return in.nextDouble();
             } catch (NumberFormatException ignored) {
                 // Fall back to return null
+                in.skipValue();
             }
         }
         return null;

--- a/gsonpath/src/test/java/gsonpath/GsonUtilTest.java
+++ b/gsonpath/src/test/java/gsonpath/GsonUtilTest.java
@@ -1,0 +1,121 @@
+package gsonpath;
+
+import com.google.gson.stream.JsonReader;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import static gsonpath.GsonUtil.isValidValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class GsonUtilTest {
+
+    private static final String NON_NUMBER = "non-number";
+    private static final String NUMBER = "number";
+    private static final String NULL_NUMBER = "null-number";
+
+    private static final byte[] testData =
+            ("{\"" + NON_NUMBER + "\":\"\",\"" +
+                    NUMBER + "\":5,\"" +
+                    NULL_NUMBER + "\":null}").getBytes();
+
+    private JsonReader in;
+
+    @Before
+    public void setUp() throws IOException {
+        in = new JsonReader(new InputStreamReader(new ByteArrayInputStream(testData)));
+        if (!isValidValue(in)) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testGetIntegerSafely() {
+        try {
+            in.beginObject();
+            while (in.hasNext()) {
+                switch (in.nextName()) {
+                    case NON_NUMBER:
+                        assertNull(GsonUtil.getIntegerSafely(in));
+                        break;
+                    case NUMBER:
+                        assertEquals(Integer.valueOf(5), GsonUtil.getIntegerSafely(in));
+                        break;
+                    case NULL_NUMBER:
+                        assertNull(GsonUtil.getIntegerSafely(in));
+                        break;
+                    default:
+                        in.skipValue();
+                        break;
+
+                }
+            }
+            in.endObject();
+        }
+        catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testGetLongSafely() {
+        try {
+            in.beginObject();
+            while (in.hasNext()) {
+                switch (in.nextName()) {
+                    case NON_NUMBER:
+                        assertNull(GsonUtil.getLongSafely(in));
+                        break;
+                    case NUMBER:
+                        assertEquals(Long.valueOf(5), GsonUtil.getLongSafely(in));
+                        break;
+                    case NULL_NUMBER:
+                        assertNull(GsonUtil.getLongSafely(in));
+                        break;
+                    default:
+                        in.skipValue();
+                        break;
+
+                }
+            }
+            in.endObject();
+        }
+        catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testGetDoubleSafely() {
+        try {
+            in.beginObject();
+            while (in.hasNext()) {
+                switch (in.nextName()) {
+                    case NON_NUMBER:
+                        assertNull(GsonUtil.getDoubleSafely(in));
+                        break;
+                    case NUMBER:
+                        assertEquals(Double.valueOf(5), GsonUtil.getDoubleSafely(in));
+                        break;
+                    case NULL_NUMBER:
+                        assertNull(GsonUtil.getDoubleSafely(in));
+                        break;
+                    default:
+                        in.skipValue();
+                        break;
+
+                }
+            }
+            in.endObject();
+        }
+        catch (Exception e) {
+            fail();
+        }
+    }
+}


### PR DESCRIPTION
Hi Lachlan,

Ideally, it is not required.
Somehow backend sending empty string in Number type.
And it failed to parse JSON.

I just added to handle in this case.

Could you please check and review those changes?

If you agree, it could be good to included in the library.
